### PR TITLE
Update manifest.toml

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -62,7 +62,7 @@ ram.runtime = "50M"
     main.url = "/"
 
     [resources.apt]
-    packages = "mariadb-server, php8.4-mysqli, php8.4-pdo"
+    packages = "mariadb-server, php8.4-mysqli, php8.4-pdo, php8.4-mbstring"
 
     [resources.database]
     type = "mysql"


### PR DESCRIPTION
Prise en compte de l'issue #70 , je pense que l'ajout du paquet manquant **php8.4-mbstring** devrait regler le probleme.

## Problem

- *php8.4-mbstring package is missing*

## Solution

- ajout du paquet php8.4-mbstring

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
